### PR TITLE
Update to Play 2.5.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Scala client for Aylien text analysis API
 
-It's a [Play! WS](https://www.playframework.com/documentation/2.4.x/ScalaWS) based API client for [Aylien's text analysis API](http://aylien.com/text-api).
+It's a [Play! 2.5 WS](https://www.playframework.com/documentation/2.5.x/ScalaWS) based API client for [Aylien's text analysis API](http://aylien.com/text-api).
 
 ## Usage example
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 
-name := "play-aylien-client"
+name := "aylien-client-play25"
 
 organization := "com.kinja"
 

--- a/build.sbt
+++ b/build.sbt
@@ -3,10 +3,10 @@ name := "play-aylien-client"
 
 organization := "com.kinja"
 
-version := "0.3.0" //-SNAPSHOT"
+version := "0.4.0" //-SNAPSHOT"
 
 scalaVersion := "2.11.8"
 
-libraryDependencies += "com.typesafe.play" %% "play-ws" % "2.4.6"
+libraryDependencies += "com.typesafe.play" %% "play-ws" % "2.5.8"
 
 initialCommands in console := """import scala.concurrent.ExecutionContext.Implicits.global; import play.api.libs.json._; import com.kinja.play.aylien.textapi._, model._; val config = TextApiClientConfig(new java.net.URL("http://api.aylien.com/api/v1"), System.getenv("AYLIEN_APP_ID"), System.getenv("AYLIEN_APP_KEY"), "iptc-subjectcode", scala.concurrent.duration.Duration("30 seconds"), play.api.libs.ws.ning.NingWSClient(), scala.concurrent.ExecutionContext.Implicits.global)"""

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ name := "aylien-client-play25"
 
 organization := "com.kinja"
 
-version := "0.4.0" //-SNAPSHOT"
+version := "1.0.0"
 
 scalaVersion := "2.11.8"
 

--- a/src/main/scala/com/kinja/play/aylien/textapi/TextAPIClient.scala
+++ b/src/main/scala/com/kinja/play/aylien/textapi/TextAPIClient.scala
@@ -54,7 +54,7 @@ final class TextApiClient(config: TextApiClientConfig) {
 				HeaderNames.ACCEPT -> MimeTypes.JSON,
 				"X-AYLIEN-TextAPI-Application-Key" -> config.appKey,
 				"X-AYLIEN-TextAPI-Application-ID" -> config.appId)
-			.withRequestTimeout(config.requestTimeout.toMillis.toLong)
+			.withRequestTimeout(config.requestTimeout)
 			.withQueryString(params:_*)
 			.get()
 	}
@@ -70,7 +70,7 @@ final class TextApiClient(config: TextApiClientConfig) {
 				HeaderNames.ACCEPT -> MimeTypes.JSON,
 				"X-AYLIEN-TextAPI-Application-Key" -> config.appKey,
 				"X-AYLIEN-TextAPI-Application-ID" -> config.appId)
-			.withRequestTimeout(config.requestTimeout.toMillis.toLong)
+			.withRequestTimeout(config.requestTimeout)
 			.post(params)
 	}
 


### PR DESCRIPTION
the `WSRequest.withRequestTimeout` function doesn't accept `Long` parameters anymore. 

@balagez can you please take a look?